### PR TITLE
Load map file in non-strict mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ module.exports.tm2z = tm2z;
 module.exports.xray = xray;
 module.exports.mapnik = mapnik;
 module.exports.Backend = Backend;
-module.exports.strict = true;
+module.exports.strict = false;
 
 function md5(str) {
     return crypto.createHash('md5').update(str).digest('hex');

--- a/test/tm2z.js
+++ b/test/tm2z.js
@@ -197,10 +197,9 @@ test('errors out on invalid project.xml', function(t) {
         t.end();
     });
 });
-test('errors out if style references a missing font', function(t) {
+test('does not error out if style references a missing font', function(t) {
     tilelive.load('tm2z://' + path.join(fixtureDir, 'missing_font.tm2z'), function(err, source) {
-        t.equal('EMAPNIK', err.code);
-        t.equal(err.message.split("'")[0], 'Failed to find font face ');
+        t.ifError(err);
         t.end();
     });
 });


### PR DESCRIPTION
Needed to avoid errors with fonts.

Bug: https://phabricator.wikimedia.org/T195513